### PR TITLE
Use correct BPlusTree Implementation in Ex2Main.kt

### DIFF
--- a/src/main/kotlin/exercise2/Ex2Main.kt
+++ b/src/main/kotlin/exercise2/Ex2Main.kt
@@ -37,7 +37,7 @@ fun main() {
     )
     println(root)
 
-    val tree: AbstractBPlusTree = BPlusTreeJava(root)
+    val tree: AbstractBPlusTree = BPlusTreeKotlin(root)
     println(tree)
 
     /*


### PR DESCRIPTION
We found that the Kotlin main function still uses the Java Implementation of BPlusTree and changed it to BPlusTreeKotlin